### PR TITLE
feat: improve auto-lock on popup close and return empty accounts when…

### DIFF
--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -36,7 +36,7 @@ export default defineManifest(async env => ({
       matches: ['<all_urls>'],
     },
   ],
-  permissions: ['storage', 'unlimitedStorage', 'activeTab'],
+  permissions: ['storage', 'unlimitedStorage', 'activeTab', 'alarms'],
   icons: {
     '16': 'images/logo.png',
     '48': 'images/logo.png',

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -19,13 +19,30 @@ import {getLedgerService} from './service/ledger.service';
 // Set Buffer globally
 globalThis.Buffer = Buffer;
 
+const LOCK_ALARM_NAME = 'walletAutoLock';
+const SW_START_TIME = Date.now();
+
 let isStorageLoaded = false;
+let walletStoreReady: Promise<void>;
+let resolveWalletStore: () => void;
+walletStoreReady = new Promise(resolve => {
+  resolveWalletStore = resolve;
+});
 
 loadAllStorage();
+
+browser.alarms.onAlarm.addListener(async (alarm) => {
+  if (alarm.name === LOCK_ALARM_NAME) {
+    if (walletProvider.isUnlocked()) {
+      await walletProvider.lockWallet();
+    }
+  }
+});
 
 async function init() {
   const walletStorage = await storage.get('WALLET_STORAGE');
   walletService.init(walletStorage);
+  resolveWalletStore();
   walletService.store.subscribe(async value => {
     await storage.set('WALLET_STORAGE', value);
   });
@@ -42,6 +59,9 @@ browser.runtime.onConnect.addListener(port => {
     port.name === 'notification' ||
     port.name === 'tab'
   ) {
+    storage.set('SW_START_TIME', SW_START_TIME);
+    browser.alarms.clear(LOCK_ALARM_NAME);
+
     // check if popup closed
     port.onDisconnect.addListener(async () => {
       // check list pending orders
@@ -71,6 +91,14 @@ browser.runtime.onConnect.addListener(port => {
           }
         }
       }
+
+      if (walletProvider.isUnlocked()) {
+        const lockTimeoutSeconds = (await storage.get('LOCK_TIMEOUT_SECONDS') as number) ?? 300;
+        await storage.set('POPUP_CLOSE_TIME', Date.now());
+        await browser.alarms.create(LOCK_ALARM_NAME, {
+          delayInMinutes: Math.max(1, Math.ceil(lockTimeoutSeconds / 60)),
+        });
+      }
     });
 
     const pm = new PortMessage(port);
@@ -83,6 +111,11 @@ browser.runtime.onConnect.addListener(port => {
           case 'provider':
           default:
             if (data.method && walletProvider[data.method]) {
+              if (!walletService.store) {
+                return walletStoreReady.then(() =>
+                  walletProvider[data.method].apply(null, data.params)
+                );
+              }
               return walletProvider[data.method].apply(null, data.params);
             } else {
               throw new Error(`Method not found: ${data.method}`);

--- a/src/background/internal/controller.ts
+++ b/src/background/internal/controller.ts
@@ -51,7 +51,7 @@ class InternalProvider {
     }
 
     if (!authService.memStore.getState().isUnlocked) {
-      return [];
+      return null;
     }
 
     const _account = await walletProvider.getActiveAccount();
@@ -369,6 +369,10 @@ class InternalProvider {
 
   @Reflect.metadata('SAFE', true)
   tracGetAddress = async ({ session: { origin } }) => {
+    if (!authService.memStore.getState().isUnlocked) {
+      return null;
+    }
+
     // Check if origin has TRAC permission
     if (!permissionService.hasTracPermission(origin)) {
       throw new Error('Not connected. Please call requestAccount() first.');

--- a/src/background/internal/controller.ts
+++ b/src/background/internal/controller.ts
@@ -1,5 +1,5 @@
 import { ethErrors } from 'eth-rpc-errors';
-import { permissionService, sessionService, networkConfig, notificationService } from '../service/singleton';
+import { permissionService, sessionService, networkConfig, notificationService, authService } from '../service/singleton';
 import { bitcoin, getBitcoinNetwork } from '../utils';
 import walletProvider from '../provider';
 import { NETWORK_TYPES, Network } from '../../wallet-instance';
@@ -47,6 +47,10 @@ class InternalProvider {
   @Reflect.metadata('SAFE', true)
   getAccounts = async ({ session: { origin } }) => {
     if (!permissionService.hasPermission(origin)) {
+      return [];
+    }
+
+    if (!authService.memStore.getState().isUnlocked) {
       return [];
     }
 

--- a/src/background/internal/request-flow.ts
+++ b/src/background/internal/request-flow.ts
@@ -95,7 +95,7 @@ const flowContext = flow
 
     // TRAC auto-connect check (for methods other than tracRequestAccount)
     if (['tracGetAddress', 'tracGetBalance', 'tracGetPublicKey', 'tracSignMessage', 'tracSendTNK', 'tracBuildTx', 'tracSignTx', 'tracPushTx'].includes(mapMethod)) {
-      if (!permissionService.hasTracPermission(origin)) {
+      if (!permissionService.hasTracPermission(origin) && authService.memStore.getState().isUnlocked) {
         ctx.request.requestedApproval = true;
         ctx.approvalRes = await notificationService.requestApproval(
           {

--- a/src/ui/hook/use-auto-lock.tsx
+++ b/src/ui/hook/use-auto-lock.tsx
@@ -3,11 +3,12 @@ import { useNavigate } from 'react-router-dom';
 import { useWalletProvider } from '../gateway/wallet-provider';
 import { useAppSelector } from '../utils';
 import { GlobalSelector } from '../redux/reducer/global/selector';
+import browser from 'webextension-polyfill';
 
 const DEFAULT_LOCK_TIMEOUT = 300; // 5 minutes in seconds
 const DEFAULT_CHECK_INTERVAL = 30; // 30 seconds
 
-const ACTIVITY_EVENTS = ['mousemove', 'keydown', 'click', 'scroll'] as const; 
+const ACTIVITY_EVENTS = ['mousemove', 'keydown', 'click', 'scroll'] as const;
 
 /**
  * Hook to automatically lock wallet after inactivity period.
@@ -16,18 +17,59 @@ const ACTIVITY_EVENTS = ['mousemove', 'keydown', 'click', 'scroll'] as const;
  * @param {number} checkIntervalSeconds - Interval in seconds between checks. Default is 30 seconds.
  */
 export function useAutoLock(
-  lockTimeoutSeconds = DEFAULT_LOCK_TIMEOUT, 
+  lockTimeoutSeconds = DEFAULT_LOCK_TIMEOUT,
   checkIntervalSeconds = DEFAULT_CHECK_INTERVAL
 ) {
   const navigate = useNavigate();
   const wallet = useWalletProvider();
   const isUnlocked = useAppSelector(GlobalSelector.isUnlocked);
-  
+
   const countdownRef = useRef<NodeJS.Timeout | null>(null);
   const timeLeftRef = useRef<number>(lockTimeoutSeconds);
   const lastActivityRef = useRef<number>(Date.now());
   const isTabVisibleRef = useRef<boolean>(true);
   const isLockingRef = useRef<boolean>(false);
+
+  // Sync timeout value to storage so the background alarm uses the correct delay
+  useEffect(() => {
+    browser.storage.local.set({ LOCK_TIMEOUT_SECONDS: lockTimeoutSeconds });
+  }, [lockTimeoutSeconds]);
+
+  // When popup reopens and wallet is still unlocked, check if it was closed past the timeout.
+  // Needed for short timeouts where the background alarm (min 1 min) hasn't fired yet.
+  useEffect(() => {
+    if (!isUnlocked) return;
+
+    const checkPopupCloseLock = async () => {
+      const result = await browser.storage.local.get(['POPUP_CLOSE_TIME', 'SW_START_TIME']);
+      const closeTime = result['POPUP_CLOSE_TIME'] as number | null;
+      const swStartTime = result['SW_START_TIME'] as number | null;
+      await browser.storage.local.remove('POPUP_CLOSE_TIME');
+
+      if (!closeTime) return;
+
+      // If POPUP_CLOSE_TIME is older than the current SW session it's stale — ignore.
+      // This avoids false locks after an extension update or SW restart.
+      if (swStartTime && closeTime <= swStartTime) return;
+
+      const elapsed = (Date.now() - closeTime) / 1000;
+      if (elapsed >= lockTimeoutSeconds) {
+        if (isLockingRef.current) return;
+        isLockingRef.current = true;
+        try {
+          await wallet.lockWallet();
+        } catch (e) {
+          console.error('❌ AutoLock (popup closed):', e);
+        } finally {
+          isLockingRef.current = false;
+          navigate('/login');
+        }
+      }
+    };
+
+    checkPopupCloseLock();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isUnlocked]);
 
   /**
    * Function to clean up countdown timer.
@@ -47,7 +89,7 @@ export function useAutoLock(
     if (isLockingRef.current) {
       return;
     }
-    
+
     isLockingRef.current = true;
     try {
       await wallet.lockWallet();
@@ -68,11 +110,11 @@ export function useAutoLock(
     if (isUnlocked) {
       timeLeftRef.current = lockTimeoutSeconds;
       lastActivityRef.current = Date.now();
-      
+
       countdownRef.current = setInterval(async () => {
         const now = Date.now();
         const timeSinceLastActivity = (now - lastActivityRef.current) / 1000;
-        
+
         // If tab is visible, use normal countdown
         if (isTabVisibleRef.current) {
           timeLeftRef.current -= checkIntervalSeconds;
@@ -81,7 +123,7 @@ export function useAutoLock(
           timeLeftRef.current -= timeSinceLastActivity;
           lastActivityRef.current = now;
         }
-        
+
         if (timeLeftRef.current <= 0) {
           clearTimers();
           // Double-check unlock status before locking


### PR DESCRIPTION
… locked

- Add background alarm to lock wallet when popup is closed past timeout
- Store POPUP_CLOSE_TIME and SW_START_TIME to handle short timeouts and stale state
- Fix race condition with walletStoreReady before walletService.store is initialized
- Add alarms permission to manifest
- Return empty array from getAccounts() when wallet is locked