### PR TITLE
feat(trac): add testtrac testnet support with network-specific addresses

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "redux-saga": "^1.3.0",
     "reflect-metadata": "^0.2.2",
     "swiper": "^12.1.2",
-    "trac-crypto-api": "^0.1.4",
+    "trac-crypto-api": "0.1.5",
     "vite-plugin-node-polyfills": "^0.22.0",
     "web3-validator": "^2.0.6",
     "webextension-polyfill": "^0.12.0",

--- a/src/background/constants/trac-api.ts
+++ b/src/background/constants/trac-api.ts
@@ -5,7 +5,7 @@
 import { Network } from '../../wallet-instance';
 
 export const TRAC_BASE_URL_MAINNET = 'https://tracapi.trac.network/v1';
-export const TRAC_BASE_URL_TESTNET = 'https://tracapi-testnet.trac.network/v1';
+export const TRAC_BASE_URL_TESTNET = 'http://trac.intern.ungueltig.com:5000/v1';
 export const TRAC_EXPLORER_URL_MAINNET = 'https://explorer.trac.network';
 export const TRAC_EXPLORER_URL_TESTNET = 'https://tracapi-testnet.trac.network';
 

--- a/src/background/internal/controller.ts
+++ b/src/background/internal/controller.ts
@@ -448,7 +448,8 @@ class InternalProvider {
     // Generate keypair to get public key
     const keypair = await TracApiService.generateKeypairFromMnemonic(
       mnemonic,
-      _account.index ?? 0
+      _account.index ?? 0,
+      networkConfig.getActiveNetwork()
     );
 
     // Convert publicKey to hex string
@@ -502,7 +503,8 @@ class InternalProvider {
       // Generate keypair
       const keypair = await TracApiService.generateKeypairFromMnemonic(
         mnemonic,
-        _account.index ?? 0
+        _account.index ?? 0,
+        networkConfig.getActiveNetwork()
       );
 
       // Sign message
@@ -636,7 +638,8 @@ class InternalProvider {
     const validity = await TracApi.fetchTransactionValidity(network);
 
     // Pre-build transaction to get all details (including fee)
-    const networkId = network === Network.MAINNET ? 918 : 9180;
+    const tracCrypto = TracApiService.getTracCryptoInstance();
+    const networkId = network === Network.MAINNET ? tracCrypto?.MAINNET_ID ?? 918 : tracCrypto?.TESTNET_ID ?? 919;
     const txData = await TracApiService.preBuildTransaction(
       { from: fromAddress, to, amountHex, validityHex: validity },
       networkId
@@ -710,7 +713,8 @@ class InternalProvider {
 
     const keypair = await TracApiService.generateKeypairFromMnemonic(
       mnemonic,
-      indices.accountIndex
+      indices.accountIndex,
+      network
     );
 
     // Sign the pre-built transaction
@@ -768,7 +772,8 @@ class InternalProvider {
       const mnemonicData = await walletProvider.getMnemonicsUnlocked(_wallet);
       const keypair = await TracApiService.generateKeypairFromMnemonic(
         mnemonicData.mnemonic,
-        accountIndex
+        accountIndex,
+        networkConfig.getActiveNetwork()
       );
 
       try {

--- a/src/background/provider.ts
+++ b/src/background/provider.ts
@@ -1797,16 +1797,16 @@ export class Provider {
   };
 
 
-  getTracAddress = (walletIndex: number, accountIndex: number): string | null => {
-    return accountConfig.getTracAddress(walletIndex, accountIndex);
+  getTracAddress = (walletIndex: number, accountIndex: number, network?: Network): string | null => {
+    return accountConfig.getTracAddress(walletIndex, accountIndex, network ?? this.getActiveNetwork());
   };
 
-  setTracAddress = (walletIndex: number, accountIndex: number, address: string) => {
-    accountConfig.setTracAddress(walletIndex, accountIndex, address);
+  setTracAddress = (walletIndex: number, accountIndex: number, address: string, network?: Network) => {
+    accountConfig.setTracAddress(walletIndex, accountIndex, address, network ?? this.getActiveNetwork());
   };
 
-  getWalletTracAddresses = (walletIndex: number): { [accountIndex: string]: string } => {
-    return accountConfig.getWalletTracAddresses(walletIndex);
+  getWalletTracAddresses = (walletIndex: number, network?: Network): { [accountIndex: string]: string } => {
+    return accountConfig.getWalletTracAddresses(walletIndex, network ?? this.getActiveNetwork());
   };
 
   removeTracAddress = (walletIndex: number, accountIndex: number) => {

--- a/src/background/service/configuration/account.ts
+++ b/src/background/service/configuration/account.ts
@@ -2,6 +2,7 @@ import {
   EVENTS,
   IDisplayAccount,
   Inscription,
+  Network,
   UnspentOutput,
 } from '@/src/wallet-instance';
 import createPersistStore from '../../storage/persistStore';
@@ -211,18 +212,30 @@ export class AccountConfigService {
     return this.store?.tracAddressMap || {};
   }
 
-  getTracAddress(walletIndex: number, accountIndex: number): string | null {
+  getTracAddress(walletIndex: number, accountIndex: number, network?: Network): string | null {
     const tracMap = this.getTracAddressMap();
-    const key = `wallet_${walletIndex}#${accountIndex}`;
-    return tracMap[key] || null;
+    if (network) {
+      const networkKey = `wallet_${walletIndex}#${accountIndex}@${network}`;
+      if (tracMap[networkKey]) return tracMap[networkKey];
+      // Fallback to legacy key only for MAINNET (old addresses stored without network suffix)
+      if (network === Network.MAINNET) {
+        const legacyKey = `wallet_${walletIndex}#${accountIndex}`;
+        return tracMap[legacyKey] || null;
+      }
+      return null;
+    }
+    const legacyKey = `wallet_${walletIndex}#${accountIndex}`;
+    return tracMap[legacyKey] || null;
   }
 
-  setTracAddress(walletIndex: number, accountIndex: number, address: string) {
+  setTracAddress(walletIndex: number, accountIndex: number, address: string, network?: Network) {
     if (!this.store?.tracAddressMap) {
       this.store.tracAddressMap = {};
     }
 
-    const key = `wallet_${walletIndex}#${accountIndex}`;
+    const key = network
+      ? `wallet_${walletIndex}#${accountIndex}@${network}`
+      : `wallet_${walletIndex}#${accountIndex}`;
     this.store.tracAddressMap = Object.assign({}, this.store.tracAddressMap, {
       [key]: address,
     });
@@ -230,14 +243,14 @@ export class AccountConfigService {
 
   getIndicesByTracAddress(address: string): { walletIndex: number; accountIndex: number } | null {
     const tracMap = this.getTracAddressMap();
-    const entry = Object.entries(tracMap).find(([key, addr]) => addr === address);
+    const entry = Object.entries(tracMap).find(([, addr]) => addr === address);
 
     if (!entry) {
       return null;
     }
 
-    const [key] = entry;
-    const match = key.match(/wallet_(\d+)#(\d+)/);
+    const [entryKey] = entry;
+    const match = entryKey.match(/wallet_(\d+)#(\d+)/);
 
     if (match) {
       return {
@@ -249,14 +262,31 @@ export class AccountConfigService {
   }
 
 
-  getWalletTracAddresses(walletIndex: number): {[accountIndex: string]: string} {
+  getWalletTracAddresses(walletIndex: number, network?: Network): {[accountIndex: string]: string} {
     const tracMap = this.getTracAddressMap();
     const result: {[accountIndex: string]: string} = {};
+    const suffix = network ? `@${network}` : '';
 
     Object.keys(tracMap).forEach(key => {
       if (key.startsWith(`wallet_${walletIndex}#`)) {
-        const accountIndex = key.split('#')[1];
-        result[accountIndex] = tracMap[key];
+        if (network) {
+          // Network-specific key matches
+          if (key.endsWith(suffix)) {
+            const accountIndex = key.split('#')[1].split('@')[0];
+            result[accountIndex] = tracMap[key];
+          } else if (network === Network.MAINNET && !key.includes('@')) {
+            // Legacy mainnet keys (no suffix) — backward compatible
+            const accountIndex = key.split('#')[1];
+            if (!result[accountIndex]) {
+              result[accountIndex] = tracMap[key];
+            }
+          }
+        } else {
+          if (!key.includes('@')) {
+            const accountIndex = key.split('#')[1];
+            result[accountIndex] = tracMap[key];
+          }
+        }
       }
     });
 
@@ -268,9 +298,15 @@ export class AccountConfigService {
       return;
     }
 
-    const key = `wallet_${walletIndex}#${accountIndex}`;
-    const updatedTracMap = {...this.store.tracAddressMap};
-    delete updatedTracMap[key];
+    const tracMap = this.getTracAddressMap();
+    const updatedTracMap = {...tracMap};
+    const keyPrefix = `wallet_${walletIndex}#${accountIndex}`;
+
+    Object.keys(tracMap).forEach(key => {
+      if (key === keyPrefix || key.startsWith(`${keyPrefix}@`)) {
+        delete updatedTracMap[key];
+      }
+    });
 
     this.store.tracAddressMap = updatedTracMap;
   }

--- a/src/background/service/trac-api.service.ts
+++ b/src/background/service/trac-api.service.ts
@@ -4,6 +4,7 @@
 
 import TracCrypto from 'trac-crypto-api';
 import * as Blake3Module from '@tracsystems/blake3';
+import { Network } from '../../wallet-instance';
 
 type Blake3Fn = (data: string | Buffer | Uint8Array) => Promise<Uint8Array>;
 const blake3Raw = (Blake3Module as any).blake3 as Blake3Fn;
@@ -39,6 +40,18 @@ export interface GeneratedKeypair {
   publicKey: string;
 }
 
+export const TRAC_HRP_MAINNET = 'trac';
+export const TRAC_HRP_TESTNET = 'testtrac';
+
+export function getTracHrp(network: Network): string {
+  return network === Network.TESTNET ? TRAC_HRP_TESTNET : TRAC_HRP_MAINNET;
+}
+
+export function getTracDerivationPath(accountIndex: number, network: Network = Network.MAINNET): string {
+  const coinType = network === Network.TESTNET ? 919 : 918;
+  return `m/${coinType}'/0'/0'/${accountIndex}'`;
+}
+
 export class TracApiService {
   /**
    * Get trac-crypto-api instance
@@ -56,15 +69,17 @@ export class TracApiService {
    */
   static async generateKeypairFromMnemonic(
     mnemonic: string,
-    accountIndex: number
+    accountIndex: number,
+    network: Network = Network.MAINNET
   ): Promise<GeneratedKeypair> {
     const tracCrypto = this.getTracCryptoInstance();
     if (!tracCrypto) {
       throw new Error("TracCryptoApi not available");
     }
 
-    const tracDerivationPath = `m/918'/0'/0'/${accountIndex}'`;
-    const generated = await tracCrypto.address.generate('trac', mnemonic, tracDerivationPath);
+    const hrp = getTracHrp(network);
+    const tracDerivationPath = getTracDerivationPath(accountIndex, network);
+    const generated = await tracCrypto.address.generate(hrp, mnemonic, tracDerivationPath);
 
     if (!generated || !generated.secretKey) {
       throw new Error("Failed to generate keypair from mnemonic");
@@ -144,13 +159,14 @@ export class TracApiService {
   /**
    * Derive address from secret key bytes
    */
-  static async addressFromSecretKey(secretBytes: Uint8Array | Buffer): Promise<{address: string}> {
+  static async addressFromSecretKey(secretBytes: Uint8Array | Buffer, network: Network = Network.MAINNET): Promise<{address: string}> {
     const tracCrypto = TracCrypto as any;
     if (!tracCrypto?.address?.fromSecretKey) {
       throw new Error("TracCryptoApi.address.fromSecretKey not available");
     }
-    
-    const result = await tracCrypto.address.fromSecretKey('trac', secretBytes);
+
+    const hrp = getTracHrp(network);
+    const result = await tracCrypto.address.fromSecretKey(hrp, secretBytes);
     if (!result?.address) {
       throw new Error("Failed to derive address from secret key");
     }
@@ -327,29 +343,25 @@ export class TracApiService {
   /**
    * Validate TRAC address format with improved checks
    */
+  static readonly VALID_TRAC_HRPS = [TRAC_HRP_MAINNET, TRAC_HRP_TESTNET];
+
   static isValidTracAddress(addr: string): boolean {
     const a = addr.trim();
     if (!a) return false;
 
-    // Basic format check: must start with 'trac' and be lowercase alphanumeric
-    if (!/^trac[0-9a-z]+$/.test(a)) return false;
+    if (!/^(trac|testtrac)[0-9a-z]+$/.test(a)) return false;
 
-    // Check if it's a valid bech32m format
-    // TRAC addresses use bech32m encoding with variable HRP length
-    const separatorIndex = a.indexOf('1');
+    const separatorIndex = a.lastIndexOf('1');
     if (separatorIndex === -1) return false;
 
     const prefix = a.slice(0, separatorIndex);
     const suffix = a.slice(separatorIndex + 1);
 
-    // HRP must be 'trac' (4 characters)
-    if (prefix !== 'trac') return false;
+    if (!this.VALID_TRAC_HRPS.includes(prefix)) return false;
 
-    // Suffix must be valid bech32 characters and have correct length
     const bech32Chars = /^[qpzry9x8gf2tvdw0s3jn54khce6mua7l]+$/;
     if (!bech32Chars.test(suffix)) return false;
 
-    // Suffix length should be: Math.ceil((32 * 8) / 5) + 6 = 58 characters
     const expectedSuffixLength = Math.ceil((32 * 8) / 5) + 6; // 58
     if (suffix.length !== expectedSuffixLength) return false;
 
@@ -364,12 +376,11 @@ export class TracApiService {
 
     if (!a) return { valid: false, error: 'Address cannot be empty' };
 
-    if (!/^trac[0-9a-z]+$/.test(a)) {
-      return { valid: false, error: 'Invalid TRAC address format. Must start with "trac" and contain only lowercase letters and numbers' };
+    if (!/^(trac|testtrac)[0-9a-z]+$/.test(a)) {
+      return { valid: false, error: 'Invalid TRAC address format. Must start with "trac" or "testtrac" and contain only lowercase letters and numbers' };
     }
 
-    // Check bech32m format
-    const separatorIndex = a.indexOf('1');
+    const separatorIndex = a.lastIndexOf('1');
     if (separatorIndex === -1) {
       return { valid: false, error: 'Invalid TRAC address format. Must contain separator "1"' };
     }
@@ -377,8 +388,8 @@ export class TracApiService {
     const prefix = a.slice(0, separatorIndex);
     const suffix = a.slice(separatorIndex + 1);
 
-    if (prefix !== 'trac') {
-      return { valid: false, error: 'Invalid TRAC address prefix. Must start with "trac"' };
+    if (!this.VALID_TRAC_HRPS.includes(prefix)) {
+      return { valid: false, error: 'Invalid TRAC address prefix. Must be "trac" or "testtrac"' };
     }
 
     const bech32Chars = /^[qpzry9x8gf2tvdw0s3jn54khce6mua7l]+$/;

--- a/src/ui/gateway/wallet-provider.tsx
+++ b/src/ui/gateway/wallet-provider.tsx
@@ -291,9 +291,9 @@ export interface IWalletProvider {
   // TRAC Address Management Methods
   getTracAddressMap(): Promise<{ [key: string]: string }>;
   getIndicesByTracAddress(address: string): Promise<{ walletIndex: number; accountIndex: number } | null>;
-  getTracAddress(walletIndex: number, accountIndex: number): Promise<string | null>;
-  setTracAddress(walletIndex: number, accountIndex: number, address: string): void;
-  getWalletTracAddresses(walletIndex: number): { [accountIndex: string]: string };
+  getTracAddress(walletIndex: number, accountIndex: number, network?: Network): Promise<string | null>;
+  setTracAddress(walletIndex: number, accountIndex: number, address: string, network?: Network): void;
+  getWalletTracAddresses(walletIndex: number, network?: Network): { [accountIndex: string]: string };
   removeTracAddress(walletIndex: number, accountIndex: number): void;
   removeWalletTracAddresses(walletIndex: number): number;
   clearAllTracAddresses(): number;

--- a/src/ui/pages/approval/components/send-tnk-approval.tsx
+++ b/src/ui/pages/approval/components/send-tnk-approval.tsx
@@ -148,6 +148,7 @@ export default function SendTNKApproval({ params: { session, data } }: Props) {
                 const generated = await TracApiService.generateKeypairFromMnemonic(
                     mnemonicData.mnemonic,
                     accountIndex,
+                    networkType,
                 );
                 secret = TracApiService.toSecretBuffer(generated.secretKey);
             }

--- a/src/ui/pages/approval/components/trac-connect.tsx
+++ b/src/ui/pages/approval/components/trac-connect.tsx
@@ -8,10 +8,12 @@ import WebsiteBar from '@/src/ui/component/website-bar';
 import { WalletSelector } from '@/src/ui/redux/reducer/wallet/selector';
 import { useWalletProvider } from '@/src/ui/gateway/wallet-provider';
 import { AccountSelector } from '@/src/ui/redux/reducer/account/selector';
+import { GlobalSelector } from '@/src/ui/redux/reducer/global/selector';
 import { WalletActions } from '@/src/ui/redux/reducer/wallet/slice';
 import { AccountActions } from '@/src/ui/redux/reducer/account/slice';
 import { useApproval } from '../hook';
 import LayoutApprove from '../layouts';
+import { getTracDerivationPath } from '@/src/background/service/trac-api.service';
 
 interface AccountItemProps {
     account?: IDisplayAccount;
@@ -71,7 +73,7 @@ export default function TracConnect({ params: { session } }: Props) {
     const handleConnect = async () => {
         const _wallet = await walletProvider.getActiveWallet();
         const _account = await walletProvider.getActiveAccount();
-        const address = await walletProvider.getTracAddress(_wallet.index, _account.index ?? 0);
+        const address = await walletProvider.getTracAddress(_wallet.index, _account.index ?? 0, networkType);
         resolveApproval(address);
     };
 
@@ -80,6 +82,7 @@ export default function TracConnect({ params: { session } }: Props) {
 
     const activeWallet = useAppSelector(WalletSelector.activeWallet);
     const activeAccount = useAppSelector(AccountSelector.activeAccount);
+    const networkType = useAppSelector(GlobalSelector.networkType);
 
     const dispatch = useAppDispatch();
 
@@ -95,7 +98,7 @@ export default function TracConnect({ params: { session } }: Props) {
             for (const wallet of wallets) {
                 if (typeof wallet.index === 'number') {
                     try {
-                        const addresses = await walletProvider.getWalletTracAddresses(wallet.index);
+                        const addresses = await walletProvider.getWalletTracAddresses(wallet.index, networkType);
                         map[wallet.key] = addresses || {};
                     } catch (error) {
                         map[wallet.key] = {};
@@ -116,7 +119,7 @@ export default function TracConnect({ params: { session } }: Props) {
 
     const deriveTracPath = (accountIndex?: number) => {
         const index = accountIndex ?? 0;
-        return `m/918'/0'/0'/${index}'`;
+        return getTracDerivationPath(index, networkType);
     };
 
     return (

--- a/src/ui/pages/home-flow/components/create-account.tsx
+++ b/src/ui/pages/home-flow/components/create-account.tsx
@@ -9,6 +9,7 @@ import {useAppDispatch, useAppSelector} from '@/src/ui/utils';
 import {useEffect, useState} from 'react';
 import {useNavigate} from 'react-router-dom';
 import {TracApiService} from '@/src/background/service/trac-api.service';
+import {GlobalSelector} from '@/src/ui/redux/reducer/global/selector';
 
 const CreateAccount = () => {
   //! State
@@ -19,6 +20,7 @@ const CreateAccount = () => {
   const [newAccountName, setNewAccountName] = useState<string>('');
   const [defaultName, setDefaultName] = useState<string>('');
   const activeWallet = useAppSelector(WalletSelector.activeWallet);
+  const networkType = useAppSelector(GlobalSelector.networkType);
 
   const init = async () => {
     const accountName = await wallet.getNextAccountName(activeWallet);
@@ -36,9 +38,9 @@ const CreateAccount = () => {
     mnemonic: string
   ) => {
     try {
-      const result = await TracApiService.generateKeypairFromMnemonic(mnemonic, accountIndex);
+      const result = await TracApiService.generateKeypairFromMnemonic(mnemonic, accountIndex, networkType);
       if (result?.address) {
-        wallet.setTracAddress(walletIndex, accountIndex, result.address);
+        wallet.setTracAddress(walletIndex, accountIndex, result.address, networkType);
       }
     } catch (error) {
       console.error('Error generating TRAC address:', error);

--- a/src/ui/pages/home-flow/components/modal-list-account-wallet.tsx
+++ b/src/ui/pages/home-flow/components/modal-list-account-wallet.tsx
@@ -8,6 +8,8 @@ import {WalletSelector} from '@/src/ui/redux/reducer/wallet/selector';
 import {useAppDispatch, useAppSelector} from '@/src/ui/utils';
 import {IDisplayAccount} from '@/src/wallet-instance';
 import {useNavigate} from 'react-router-dom';
+import {GlobalSelector} from '@/src/ui/redux/reducer/global/selector';
+import {getTracDerivationPath} from '@/src/background/service/trac-api.service';
 import {useReloadAccounts} from '../hook';
 import {SVG} from '@/src/ui/svg';
 
@@ -24,6 +26,7 @@ const ModalListAccountWallet = (props: IModalListAccountWalletProps) => {
   const dispatch = useAppDispatch();
   const {showToast} = useCustomToast();
   const reloadAccounts = useReloadAccounts();
+  const networkType = useAppSelector(GlobalSelector.networkType);
   const [tracAddressMap, setTracAddressMap] = useState<{
     [accountIndex: string]: string;
   }>({});
@@ -41,7 +44,7 @@ const ModalListAccountWallet = (props: IModalListAccountWalletProps) => {
       try {
         const map =
           (await Promise.resolve(
-            wallet.getWalletTracAddresses(activeWallet.index),
+            wallet.getWalletTracAddresses(activeWallet.index, networkType),
           )) || {};
         if (!ignore) {
           setTracAddressMap(map);
@@ -57,11 +60,11 @@ const ModalListAccountWallet = (props: IModalListAccountWalletProps) => {
     return () => {
       ignore = true;
     };
-  }, [wallet, activeWallet?.index, activeWallet?.accounts?.length]);
+  }, [wallet, activeWallet?.index, activeWallet?.accounts?.length, networkType]);
 
   const deriveTracPath = (accountIndex?: number) => {
     const index = accountIndex ?? 0;
-    return `m/918'/0'/0'/${index}'`;
+    return getTracDerivationPath(index, networkType);
   };
 
   //! Function

--- a/src/ui/pages/home-flow/hook/index.tsx
+++ b/src/ui/pages/home-flow/hook/index.tsx
@@ -75,10 +75,12 @@ export function useAccountBalance() {
 
 
 // Derive active TRAC address from active wallet/account indices
+// Lazy-generates address for the current network if not yet stored
 export function useActiveTracAddress() {
   const wallet = useWalletProvider();
   const activeAccount = useAppSelector(AccountSelector.activeAccount);
   const activeWallet = useAppSelector(WalletSelector.activeWallet);
+  const networkType = useAppSelector(GlobalSelector.networkType);
   const [tracAddress, setTracAddress] = useState<string>('');
 
   useEffect(() => {
@@ -89,10 +91,36 @@ export function useActiveTracAddress() {
           typeof activeWallet?.index === 'number' &&
           typeof activeAccount?.index === 'number'
         ) {
-          const addr = await wallet.getTracAddress(
+          let addr = await wallet.getTracAddress(
             activeWallet.index,
             activeAccount.index,
+            networkType,
           );
+
+          // Lazy generate: if no address for this network, derive and store it
+          if (!addr) {
+            // Try HD wallet path (mnemonic)
+            try {
+              const mnemonicData = await wallet.getMnemonicsUnlocked(activeWallet);
+              if (mnemonicData?.mnemonic) {
+                const result = await TracApiService.generateKeypairFromMnemonic(
+                  mnemonicData.mnemonic,
+                  activeAccount.index ?? 0,
+                  networkType,
+                );
+                if (result?.address) {
+                  wallet.setTracAddress(activeWallet.index, activeAccount.index ?? 0, result.address, networkType);
+                  addr = result.address;
+                }
+              }
+            } catch {
+              // Mnemonic not available
+            }
+
+            // Single Wallet TRAC: private key belongs to one network only,
+            // cannot derive correct address for another network
+          }
+
           if (!ignore) setTracAddress(addr || '');
         } else if (!ignore) {
           setTracAddress('');
@@ -105,7 +133,7 @@ export function useActiveTracAddress() {
     return () => {
       ignore = true;
     };
-  }, [wallet, activeWallet?.index, activeAccount?.index]);
+  }, [wallet, activeWallet?.index, activeAccount?.index, networkType]);
 
   return tracAddress;
 }

--- a/src/ui/pages/import-flow/choose-address-step.tsx
+++ b/src/ui/pages/import-flow/choose-address-step.tsx
@@ -13,8 +13,9 @@ import LayoutScreenImport from '../../layouts/import-export';
 import {GlobalActions} from '../../redux/reducer/global/slice';
 import {SVG} from '../../svg';
 import {colors} from '../../themes/color';
-import {TracApiService} from '@/src/background/service/trac-api.service';
-import {useAppDispatch} from '../../utils';
+import {TracApiService, getTracDerivationPath} from '@/src/background/service/trac-api.service';
+import {useAppDispatch, useAppSelector} from '../../utils';
+import {GlobalSelector} from '../../redux/reducer/global/selector';
 import {CreateWalletContext} from './services/wallet-service-create';
 import {IResponseAddressBalance} from '../../../background/requests/paid-api';
 
@@ -54,6 +55,7 @@ const ChooseAddress = () => {
   const {showToast} = useCustomToast();
   const walletProvider = useWalletProvider();
   const dispatch = useAppDispatch();
+  const networkType = useAppSelector(GlobalSelector.networkType);
   const queryParams = new URLSearchParams(location.search);
   const isImport = queryParams.get('type');
   const CreateWalletContextHandler = useContext(CreateWalletContext);
@@ -139,7 +141,7 @@ const ChooseAddress = () => {
 
   const generateTracAddress = async (mnemonic: string, accountIndex: number = 0) => {
     try {
-      const result = await TracApiService.generateKeypairFromMnemonic(mnemonic, accountIndex);
+      const result = await TracApiService.generateKeypairFromMnemonic(mnemonic, accountIndex, networkType);
       return result?.address || '';
     } catch (error) {
       console.error('Error generating TRAC address:', error);
@@ -250,7 +252,7 @@ const ChooseAddress = () => {
         const walletIndex = activeWallet?.index ?? 0;
         const accountIndex = 0; // first account for new wallet
         if (tracAddress) {
-          walletProvider.setTracAddress(walletIndex, accountIndex, tracAddress);
+          walletProvider.setTracAddress(walletIndex, accountIndex, tracAddress, networkType);
         }
       } catch (err) {
         console.log('persist TRAC address after wallet creation failed:', err);
@@ -359,7 +361,7 @@ const ChooseAddress = () => {
               <UX.CardAddress
                 isActive={true}
                 nameCardAddress="TRAC Network (TRAC)"
-                path="m/918'/0'/0'/0'"
+                path={getTracDerivationPath(0, networkType)}
                 address={tracAddress}
                 hasVault={tracBalance && parseFloat(tracBalance) > 0}
                 assets={tracBalance && parseFloat(tracBalance) > 0 ? { totalBtc: formatTracBalance(tracBalance), satoshis: 0, totalInscription: 0 } : undefined}

--- a/src/ui/pages/import-flow/restore-wallet.tsx
+++ b/src/ui/pages/import-flow/restore-wallet.tsx
@@ -8,8 +8,9 @@ import {SVG} from '../../svg';
 import {CreateWalletContext} from './services/wallet-service-create';
 import {useWalletProvider} from '../../gateway/wallet-provider';
 import {AddressType} from '@/src/wallet-instance';
-import {useAppDispatch} from '../../utils';
+import {useAppDispatch, useAppSelector} from '../../utils';
 import {WalletActions} from '../../redux/reducer/wallet/slice';
+import {GlobalSelector} from '../../redux/reducer/global/selector';
 import {AccountActions} from '../../redux/reducer/account/slice';
 import {TracApiService} from '@/src/background/service/trac-api.service';
 
@@ -21,6 +22,7 @@ const RestoreWallet = () => {
   const CreateWalletContextHandler = useContext(CreateWalletContext);
   const {showToast} = useCustomToast();
   const dispatch = useAppDispatch();
+  const networkType = useAppSelector(GlobalSelector.networkType);
   const [disabled, setDisabled] = useState(true);
   const [restoreInput, setRestoreInput] = useState('');
   const queryParams = new URLSearchParams(location.search);
@@ -90,7 +92,7 @@ const RestoreWallet = () => {
           // 1) Derive TRAC address from provided secretKey first to check for duplicates
           let tracAddress = '';
           try {
-            const result = await TracApiService.addressFromSecretKey(secretBytes);
+            const result = await TracApiService.addressFromSecretKey(secretBytes, networkType);
             tracAddress = result.address;
           } catch (error) {
             console.log('Error deriving TRAC address:', error);
@@ -153,7 +155,7 @@ const RestoreWallet = () => {
             const wallets = await walletProvider.getWallets();
             const newWallet = wallets[wallets.length - 1];
             if (newWallet) {
-              walletProvider.setTracAddress(newWallet.index, 0, tracAddress);
+              walletProvider.setTracAddress(newWallet.index, 0, tracAddress, networkType);
             }
           } catch (error) {
             console.log('Error setting TRAC address:', error);

--- a/src/ui/pages/send-receive/send-trac-pin.tsx
+++ b/src/ui/pages/send-receive/send-trac-pin.tsx
@@ -92,7 +92,8 @@ const SendTracPin = () => {
         
         const generated = await TracApiService.generateKeypairFromMnemonic(
           mnemonicData.mnemonic,
-          activeAccount.index
+          activeAccount.index,
+          networkType
         );
         
         secret = TracApiService.toSecretBuffer(generated.secretKey);

--- a/src/ui/pages/send-receive/send-trac-summary.tsx
+++ b/src/ui/pages/send-receive/send-trac-summary.tsx
@@ -85,6 +85,7 @@ const SendTracSummary = () => {
         const generated = await TracApiService.generateKeypairFromMnemonic(
           mnemonicData.mnemonic,
           activeAccount.index,
+          networkType,
         );
         secret = TracApiService.toSecretBuffer(generated.secretKey);
       }

--- a/src/ui/pages/send-receive/send-trac.tsx
+++ b/src/ui/pages/send-receive/send-trac.tsx
@@ -9,7 +9,7 @@ import {useCustomToast} from '../../component/toast-custom';
 import {useActiveTracAddress, useTracBalances} from '../home-flow/hook';
 import {useWalletProvider} from '../../gateway/wallet-provider';
 import {TracApi} from '../../../background/requests/trac-api';
-import {TracApiService} from '../../../background/service/trac-api.service';
+import {TracApiService, getTracHrp} from '../../../background/service/trac-api.service';
 import {useAppSelector} from '../../utils';
 import {GlobalSelector} from '../../redux/reducer/global/selector';
 import {Network} from '../../../wallet-instance';
@@ -85,7 +85,15 @@ const SendTrac = () => {
     if (!validation.valid) {
       setAddressError('Invalid TRAC address format');
     } else {
-      setAddressError('');
+      // Cross-network check: prevent sending to wrong network address
+      const expectedHrp = getTracHrp(networkType);
+      const separatorIndex = address.trim().lastIndexOf('1');
+      const addrPrefix = separatorIndex > 0 ? address.trim().slice(0, separatorIndex) : '';
+      if (addrPrefix !== expectedHrp) {
+        setAddressError(`This is a ${addrPrefix === 'trac' ? 'mainnet' : 'testnet'} address. You are on ${networkType === Network.MAINNET ? 'mainnet' : 'testnet'}.`);
+      } else {
+        setAddressError('');
+      }
     }
   };
 

--- a/src/ui/pages/settings/network-type.tsx
+++ b/src/ui/pages/settings/network-type.tsx
@@ -6,7 +6,7 @@ import {SVG} from '../../svg';
 import {useAppSelector} from '../../utils';
 import {GlobalSelector} from '../../redux/reducer/global/selector';
 import {useCustomToast} from '../../component/toast-custom';
-import {useReloadAccounts} from '../home-flow/hook';
+import {useReloadAccounts, useIsTracSingleWallet} from '../home-flow/hook';
 import {Network} from '@/src/wallet-instance';
 import {useChangeNetworkCallback} from './hooks';
 import {useWalletProvider} from '@/src/ui/gateway/wallet-provider';
@@ -19,6 +19,7 @@ const NetWorkType = () => {
   const {showToast} = useCustomToast();
   const reloadAccounts = useReloadAccounts();
   const walletProvider = useWalletProvider();
+  const isTracSingleWallet = useIsTracSingleWallet();
 
   //! Function
   const handleChangeNetwork = async (network: Network) => {
@@ -67,7 +68,8 @@ const NetWorkType = () => {
         <UX.Box spacing="xl" style={{padding: '0 24px'}}>
           <UX.Box
             layout="box_border"
-            onClick={() => handleChangeNetwork(Network.TESTNET)}>
+            onClick={() => !isTracSingleWallet && handleChangeNetwork(Network.TESTNET)}
+            style={isTracSingleWallet && networkType !== Network.TESTNET ? {opacity: 0.4, cursor: 'not-allowed'} : {}}>
             <UX.Text
               title="TESTNET"
               styleType="body_16_bold"
@@ -77,7 +79,8 @@ const NetWorkType = () => {
           </UX.Box>
           <UX.Box
             layout="box_border"
-            onClick={() => handleChangeNetwork(Network.MAINNET)}>
+            onClick={() => !isTracSingleWallet && handleChangeNetwork(Network.MAINNET)}
+            style={isTracSingleWallet && networkType !== Network.MAINNET ? {opacity: 0.4, cursor: 'not-allowed'} : {}}>
             <UX.Text
               title="LIVENET"
               styleType="body_16_bold"
@@ -85,6 +88,13 @@ const NetWorkType = () => {
             />
             {networkType === Network.MAINNET && <SVG.CheckIcon />}
           </UX.Box>
+          {isTracSingleWallet && (
+            <UX.Text
+              title="Network switching is disabled for TRAC-only wallets imported with private key."
+              styleType="body_12_normal"
+              customStyles={{color: '#888', textAlign: 'center'}}
+            />
+          )}
         </UX.Box>
       }
       footer={<Navbar />}

--- a/src/ui/pages/settings/security.tsx
+++ b/src/ui/pages/settings/security.tsx
@@ -14,11 +14,11 @@ import {GlobalSelector} from '../../redux/reducer/global/selector';
 import {GlobalActions} from '../../redux/reducer/global/slice';
 import {useIsTracSingleWallet} from '../home-flow/hook';
 import {TracApiService} from '@/src/background/service/trac-api.service';
-import {RestoreTypes} from '@/src/wallet-instance';
+import {Network, RestoreTypes} from '@/src/wallet-instance';
 
 // Function to derive TRAC private key from mnemonic
-const deriveTracPrivateKeyFromMnemonic = async (mnemonic: string, accountIndex: number): Promise<string> => {
-  const result = await TracApiService.generateKeypairFromMnemonic(mnemonic, accountIndex);
+const deriveTracPrivateKeyFromMnemonic = async (mnemonic: string, accountIndex: number, network: Network = Network.MAINNET): Promise<string> => {
+  const result = await TracApiService.generateKeypairFromMnemonic(mnemonic, accountIndex, network);
   if (!result?.secretKey) {
     throw new Error('Failed to derive TRAC private key');
   }
@@ -40,6 +40,7 @@ const SecuritySetting = () => {
   const activeAccount = useAppSelector(AccountSelector.activeAccount);
   const activeWallet = useAppSelector(WalletSelector.activeWallet);
   const isLegacyUser = useAppSelector(GlobalSelector.isLegacyUser);
+  const networkType = useAppSelector(GlobalSelector.networkType);
   const dispatch = useAppDispatch();
   const isTracSingleWallet = useIsTracSingleWallet();
 
@@ -80,7 +81,7 @@ const SecuritySetting = () => {
       } else {
         // For TRAC HD wallet, derive from mnemonic
         const mnemonicData = await wallet.getMnemonics(pinString, activeWallet);
-        tracPrivateKey = await deriveTracPrivateKeyFromMnemonic(mnemonicData.mnemonic, activeAccount.index);
+        tracPrivateKey = await deriveTracPrivateKeyFromMnemonic(mnemonicData.mnemonic, activeAccount.index, networkType);
       }
       
       _res = {


### PR DESCRIPTION
- Update trac-crypto-api to v0.1.5
- Add HRP testtrac and derivation path m/919' for testnet
- Fix networkId 9180 to 919
- Update testnet RPC URL
- Network-specific address storage with backward compatibility
- Lazy address generation on network switch
- Cross-network address validation
- Disable network switch for TRAC Single Wallets