### PR TITLE
85 fix new account addresses

### DIFF
--- a/src/ui/pages/home-flow/components/index.css
+++ b/src/ui/pages/home-flow/components/index.css
@@ -137,7 +137,7 @@
   flex-direction: column;
   gap: 8px;
   padding: 6px 16px;
-  z-index: 1;
+  z-index: 999;
 }
 .containerDrawer {
   display: flex;

--- a/src/ui/pages/home-flow/components/modal-list-account-wallet.tsx
+++ b/src/ui/pages/home-flow/components/modal-list-account-wallet.tsx
@@ -16,8 +16,8 @@ import {SVG} from '@/src/ui/svg';
 interface IModalListAccountWalletProps {
   handleClose?: () => void;
 }
+
 const ModalListAccountWallet = (props: IModalListAccountWalletProps) => {
-  //! State
   const {handleClose} = props;
   const navigate = useNavigate();
   const activeWallet = useAppSelector(WalletSelector.activeWallet);
@@ -33,10 +33,14 @@ const ModalListAccountWallet = (props: IModalListAccountWalletProps) => {
 
   useEffect(() => {
     reloadAccounts();
-  }, [reloadAccounts]);
+  }, [reloadAccounts, networkType]);
 
   useEffect(() => {
     let ignore = false;
+    let retryTimeout: NodeJS.Timeout;
+    let retries = 0;
+    const MAX_RETRIES = 4;
+
     const fetchTracAddresses = async () => {
       if (typeof activeWallet?.index !== 'number') {
         if (!ignore) {
@@ -50,8 +54,19 @@ const ModalListAccountWallet = (props: IModalListAccountWalletProps) => {
           (await Promise.resolve(
             wallet.getWalletTracAddresses(activeWallet.index, networkType),
           )) || {};
+        
         if (!ignore) {
           setTracAddressMap(map);
+
+          const totalAccounts = activeWallet?.accounts?.length || 0;
+          const fetchedTracCount = Object.keys(map).length;
+
+          if (fetchedTracCount > 0 && fetchedTracCount < totalAccounts && retries < MAX_RETRIES) {
+            retries++;
+            retryTimeout = setTimeout(() => {
+              if (!ignore) fetchTracAddresses();
+            }, 300);
+          }
         }
       } catch (error) {
         if (!ignore) {
@@ -61,17 +76,18 @@ const ModalListAccountWallet = (props: IModalListAccountWalletProps) => {
     };
 
     fetchTracAddresses();
+    
     return () => {
       ignore = true;
+      clearTimeout(retryTimeout);
     };
-  }, [wallet, activeWallet?.index, activeWallet?.accounts?.length, networkType]);
+  }, [wallet, activeWallet?.index, networkType, JSON.stringify(activeWallet?.accounts)]);
 
   const deriveTracPath = (accountIndex?: number) => {
     const index = accountIndex ?? 0;
     return getTracDerivationPath(index, networkType);
   };
 
-  //! Function
   const handleChangeAccount = async (account: IDisplayAccount) => {
     if (activeAccount.pubkey !== account.pubkey) {
       await wallet.changeWallet(activeWallet, account.index);
@@ -86,7 +102,6 @@ const ModalListAccountWallet = (props: IModalListAccountWalletProps) => {
     }
   };
 
-  //! Render
   return (
     <UX.Box
       style={{
@@ -120,7 +135,7 @@ const ModalListAccountWallet = (props: IModalListAccountWalletProps) => {
               isAccount
               onClick={() => handleChangeAccount(item)}
               isActive={item.index === activeAccount.index}
-              key={item.index}
+              key={`${networkType}-${item.index}`}
               nameCardAddress={item.name}
               path={btcPath}
               address={item.address}
@@ -132,11 +147,6 @@ const ModalListAccountWallet = (props: IModalListAccountWalletProps) => {
           );
         })}
       </UX.Box>
-      {/* <UX.Button
-        title="Create account"
-        styleType="primary"
-        onClick={() => navigate('/home/create-account')}
-      /> */}
     </UX.Box>
   );
 };

--- a/src/ui/pages/home-flow/components/modal-list-account-wallet.tsx
+++ b/src/ui/pages/home-flow/components/modal-list-account-wallet.tsx
@@ -12,6 +12,7 @@ import {GlobalSelector} from '@/src/ui/redux/reducer/global/selector';
 import {getTracDerivationPath} from '@/src/background/service/trac-api.service';
 import {useReloadAccounts} from '../hook';
 import {SVG} from '@/src/ui/svg';
+import {WalletDisplay} from '@/src/wallet-instance';
 
 interface IModalListAccountWalletProps {
   handleClose?: () => void;
@@ -27,22 +28,39 @@ const ModalListAccountWallet = (props: IModalListAccountWalletProps) => {
   const {showToast} = useCustomToast();
   const reloadAccounts = useReloadAccounts();
   const networkType = useAppSelector(GlobalSelector.networkType);
+  const [displayWallet, setDisplayWallet] = useState<WalletDisplay | null>(null);
   const [tracAddressMap, setTracAddressMap] = useState<{
     [accountIndex: string]: string;
   }>({});
 
   useEffect(() => {
-    reloadAccounts();
-  }, [reloadAccounts, networkType]);
+    let ignore = false;
+
+    const syncWalletState = async () => {
+      await reloadAccounts();
+      const nextWallet = await wallet.getActiveWallet();
+
+      if (!ignore) {
+        setDisplayWallet(nextWallet);
+      }
+    };
+
+    syncWalletState();
+
+    return () => {
+      ignore = true;
+    };
+  }, [reloadAccounts, wallet, networkType, activeWallet?.index]);
 
   useEffect(() => {
     let ignore = false;
-    let retryTimeout: NodeJS.Timeout;
+    let retryTimeout: ReturnType<typeof setTimeout>;
     let retries = 0;
     const MAX_RETRIES = 4;
+    const currentWallet = displayWallet || activeWallet;
 
     const fetchTracAddresses = async () => {
-      if (typeof activeWallet?.index !== 'number') {
+      if (typeof currentWallet?.index !== 'number') {
         if (!ignore) {
           setTracAddressMap({});
         }
@@ -52,13 +70,13 @@ const ModalListAccountWallet = (props: IModalListAccountWalletProps) => {
       try {
         const map =
           (await Promise.resolve(
-            wallet.getWalletTracAddresses(activeWallet.index, networkType),
+            wallet.getWalletTracAddresses(currentWallet.index, networkType),
           )) || {};
-        
+
         if (!ignore) {
           setTracAddressMap(map);
 
-          const totalAccounts = activeWallet?.accounts?.length || 0;
+          const totalAccounts = currentWallet?.accounts?.length || 0;
           const fetchedTracCount = Object.keys(map).length;
 
           if (fetchedTracCount > 0 && fetchedTracCount < totalAccounts && retries < MAX_RETRIES) {
@@ -68,7 +86,7 @@ const ModalListAccountWallet = (props: IModalListAccountWalletProps) => {
             }, 300);
           }
         }
-      } catch (error) {
+      } catch {
         if (!ignore) {
           setTracAddressMap({});
         }
@@ -76,12 +94,12 @@ const ModalListAccountWallet = (props: IModalListAccountWalletProps) => {
     };
 
     fetchTracAddresses();
-    
+
     return () => {
       ignore = true;
       clearTimeout(retryTimeout);
     };
-  }, [wallet, activeWallet?.index, networkType, JSON.stringify(activeWallet?.accounts)]);
+  }, [wallet, activeWallet, displayWallet, networkType]);
 
   const deriveTracPath = (accountIndex?: number) => {
     const index = accountIndex ?? 0;
@@ -89,11 +107,19 @@ const ModalListAccountWallet = (props: IModalListAccountWalletProps) => {
   };
 
   const handleChangeAccount = async (account: IDisplayAccount) => {
+    const currentWallet = displayWallet || activeWallet;
+
+    if (!currentWallet) {
+      return;
+    }
+
     if (activeAccount.pubkey !== account.pubkey) {
-      await wallet.changeWallet(activeWallet, account.index);
+      await wallet.changeWallet(currentWallet, account.index);
+      await reloadAccounts();
       const _activeAccount = await wallet.getActiveAccount();
+      const _activeWallet = await wallet.getActiveWallet();
       dispatch(AccountActions.setActiveAccount(_activeAccount));
-      reloadAccounts();
+      setDisplayWallet(_activeWallet);
       showToast({
         title: 'Account changed',
         type: 'success',
@@ -125,8 +151,10 @@ const ModalListAccountWallet = (props: IModalListAccountWalletProps) => {
           padding: '10px 0',
           overflowY: 'scroll',
         }}>
-        {activeWallet?.accounts?.map(item => {
-          const btcPath = `${activeWallet.derivationPath}/${item.index}`;
+        {(displayWallet?.accounts || activeWallet?.accounts || []).map(item => {
+          const derivationPath =
+            (displayWallet || activeWallet)?.derivationPath || '';
+          const btcPath = `${derivationPath}/${item.index}`;
           const accountIndexKey = String(item?.index ?? 0);
           const tracAddress = tracAddressMap?.[accountIndexKey];
 

--- a/src/ui/pages/home-flow/components/modal-list-account-wallet.tsx
+++ b/src/ui/pages/home-flow/components/modal-list-account-wallet.tsx
@@ -6,13 +6,12 @@ import {AccountSelector} from '@/src/ui/redux/reducer/account/selector';
 import {AccountActions} from '@/src/ui/redux/reducer/account/slice';
 import {WalletSelector} from '@/src/ui/redux/reducer/wallet/selector';
 import {useAppDispatch, useAppSelector} from '@/src/ui/utils';
-import {IDisplayAccount} from '@/src/wallet-instance';
+import {IDisplayAccount, WalletDisplay} from '@/src/wallet-instance';
 import {useNavigate} from 'react-router-dom';
 import {GlobalSelector} from '@/src/ui/redux/reducer/global/selector';
 import {getTracDerivationPath} from '@/src/background/service/trac-api.service';
 import {useReloadAccounts} from '../hook';
 import {SVG} from '@/src/ui/svg';
-import {WalletDisplay} from '@/src/wallet-instance';
 
 interface IModalListAccountWalletProps {
   handleClose?: () => void;

--- a/src/ui/pages/home-flow/components/modal-list-account-wallet.tsx
+++ b/src/ui/pages/home-flow/components/modal-list-account-wallet.tsx
@@ -32,6 +32,10 @@ const ModalListAccountWallet = (props: IModalListAccountWalletProps) => {
   }>({});
 
   useEffect(() => {
+    reloadAccounts();
+  }, [reloadAccounts]);
+
+  useEffect(() => {
     let ignore = false;
     const fetchTracAddresses = async () => {
       if (typeof activeWallet?.index !== 'number') {

--- a/src/ui/pages/home-flow/components/wallet-card-item.tsx
+++ b/src/ui/pages/home-flow/components/wallet-card-item.tsx
@@ -1,3 +1,4 @@
+// import './index.css';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import {
@@ -15,7 +16,6 @@ import {useAppSelector, useAppDispatch} from '@/src/ui/utils';
 import {NETWORK_TYPES, Network, WalletDisplay} from '@/src/wallet-instance';
 import {useNavigate} from 'react-router-dom';
 import {useAccountBalance, useActiveTracAddress, useIsTracSingleWallet} from '../hook';
-import './index.css';
 import {debounce} from 'lodash';
 import {useSafeBalance, useHardwareWalletMismatch} from '@/src/ui/pages/send-receive/hook';
 import {getTracExplorerUrl} from '../../../../background/constants/trac-api';
@@ -109,17 +109,18 @@ const WalletCard = (props: IWalletCardProps) => {
     const handleOutsideClick = (event: MouseEvent) => {
       if (
         ref.current &&
-        !ref.current.contains(event.target as Node) &&
-        menuOpen
+        !ref.current.contains(event.target as Node)
       ) {
         setMenuOpen(false);
       }
     };
 
-    document.addEventListener('click', handleOutsideClick);
+    if (menuOpen) {
+      document.addEventListener('mousedown', handleOutsideClick);
+    }
 
     return () => {
-      document.removeEventListener('click', handleOutsideClick);
+      document.removeEventListener('mousedown', handleOutsideClick);
     };
   }, [menuOpen]);
 
@@ -162,48 +163,63 @@ const WalletCard = (props: IWalletCardProps) => {
   //! Render
   return (
     <>
-        <div className="cardSliderContainer" style={{position: 'relative'}}>
-          {showOverlay && (
-            <UX.Box
-              layout="column_center"
-              style={{
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                right: 0,
-                bottom: 0,
-                background: 'rgba(138, 47, 61, 0.3)',
-                backdropFilter: 'blur(6px)',
-                WebkitBackdropFilter: 'blur(6px)',
-                zIndex: 6,
-                borderRadius: 16,
-                textAlign: 'center',
-                padding: '0 16px',
-              }}>
+      <div className="cardSliderContainer" style={{position: 'relative'}}>
+        {showOverlay && (
+          <UX.Box
+            layout="column_center"
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              background: 'rgba(138, 47, 61, 0.3)',
+              backdropFilter: 'blur(6px)',
+              WebkitBackdropFilter: 'blur(6px)',
+              zIndex: 6,
+              borderRadius: 16,
+              textAlign: 'center',
+              padding: '0 16px',
+            }}>
+            <UX.Text
+              styleType="body_16_bold"
+              customStyles={{color: 'white'}}
+            title={`Wallet only available on ${
+              expectedNetwork === Network.TESTNET ? 'testnet' : 'mainnet'
+            }`}
+            />
+          </UX.Box>
+        )}
+        <div className="cardSlider">
+          <UX.Box layout="row_between" style={{width: '100%', alignItems: 'center'}}>
+            <UX.Box layout="row" spacing="xs" style={{alignItems: 'center'}}>
               <UX.Text
-                styleType="body_16_bold"
-                customStyles={{color: 'white'}}
-              title={`Wallet only available on ${
-                expectedNetwork === Network.TESTNET ? 'testnet' : 'mainnet'
-              }`}
+                styleType="body_14_normal"
+                title={keyring?.name ?? 'Error'}
+                className="nameHdWallet"
               />
             </UX.Box>
-          )}
-          <div className="cardSlider">
-            <UX.Box layout="row_between" style={{width: '100%', alignItems: 'center'}}>
-              <UX.Box layout="row" spacing="xs" style={{alignItems: 'center'}}>
-                <UX.Text
-                  styleType="body_14_normal"
-                  title={keyring?.name ?? 'Error'}
-                  className="nameHdWallet"
-                />
-              </UX.Box>
-              <UX.Box ref={ref}>
+            <UX.Box layout="row" style={{alignItems: 'center', gap: '8px'}}>
+              <UX.Text 
+                styleType="body_12_bold" 
+                title={networkType === NETWORK_TYPES.MAINNET.label ? 'MAINNET' : 'TESTNET'} 
+                customStyles={{ 
+                  color: networkType === NETWORK_TYPES.MAINNET.label ? 'white' : '#d3d3d3',
+                  fontSize: '10px',
+                  letterSpacing: '0.5px',
+                  padding: '2px 6px',
+                  background: 'rgba(255,255,255,0.1)',
+                  borderRadius: '4px'
+                }} 
+              />
+
+              <div ref={ref} style={{ position: 'relative', display: 'flex' }}>
                 <UX.Box
-                  onClick={() => setMenuOpen(true)}
-                  style={{cursor: 'pointer', position: 'relative'}}>
+                  onClick={() => setMenuOpen(prev => !prev)}
+                  style={{cursor: 'pointer'}}>
                   <SVG.DotIcon />
                 </UX.Box>
+                
                 {menuOpen && (
                   <div className="containerOption">
                     {!isTracSingle && (
@@ -225,7 +241,6 @@ const WalletCard = (props: IWalletCardProps) => {
                     <UX.Text
                       onClick={async () => {
                         setMenuOpen(false);
-                        // Set active wallet if this card is not already active
                         if (keyring.key !== activeWallet.key) {
                           await wallet.setActiveWallet(keyring);
                           dispatch(WalletActions.setActiveWallet(keyring));
@@ -240,8 +255,9 @@ const WalletCard = (props: IWalletCardProps) => {
                     />
                   </div>
                 )}
-              </UX.Box>
+              </div>
             </UX.Box>
+          </UX.Box>
         </div>
         <div>
         {checkIsSingleWallet ? (
@@ -330,7 +346,6 @@ const WalletCard = (props: IWalletCardProps) => {
           </UX.Box>
         </UX.Box>
       </div>
-
     </>
   );
 };

--- a/src/ui/pages/home-flow/components/wallet-card-item.tsx
+++ b/src/ui/pages/home-flow/components/wallet-card-item.tsx
@@ -1,4 +1,3 @@
-// import './index.css';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import {
@@ -201,7 +200,7 @@ const WalletCard = (props: IWalletCardProps) => {
             </UX.Box>
             <UX.Box layout="row" style={{alignItems: 'center', gap: '8px'}}>
               <UX.Text 
-                styleType="body_12_bold" 
+                styleType="body_12_bold"
                 title={networkType === NETWORK_TYPES.MAINNET.label ? 'MAINNET' : 'TESTNET'} 
                 customStyles={{ 
                   color: networkType === NETWORK_TYPES.MAINNET.label ? 'white' : '#d3d3d3',

--- a/yarn.lock
+++ b/yarn.lock
@@ -7456,10 +7456,10 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-trac-crypto-api@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/trac-crypto-api/-/trac-crypto-api-0.1.4.tgz#5fc78eaee0d6d5150d48c974771a1ef68d638fe2"
-  integrity sha512-CI+Pxbn0SwTBa7rmmgBvLyz2E65dT9M06TmD64KM2Ub9EsSWSk+pnW+tDMTdzKPVoJx8rHPdm5B4eoMQovBTzA==
+trac-crypto-api@0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/trac-crypto-api/-/trac-crypto-api-0.1.5.tgz#e715c94a9f8674ae6c5c5f977a525f5f097eb5a6"
+  integrity sha512-3z+isJdpjJ+uSFd+TH93O72xrxEm7tJbGVRxQZtlYUOOU/FVq/mAo8E3Kwyf9dfMB3F/em1hPNdF7qloc6DFzQ==
   dependencies:
     "@metamask/key-tree" "10.1.1"
     "@tracsystems/blake3" "0.0.15"


### PR DESCRIPTION
# PR: Fix Account Creation & Network Sync Issues

## Summary
Fixed account synchronization, network switching, and UI interaction bugs.

## Fixed Bugs

1. New accounts not appearing immediately after creation.
2. TRAC addresses disappearing or failing to load when switching networks.
3. Context menu staying open after clicking outside.

## Changes

1. Account List: Added reloadAccounts on mount to show new accounts without manual refresh.
2. Network Sync: Implemented Smart Polling for TRAC addresses to fix race conditions when switching between Mainnet and Testnet.
3. UI/UX: * Fixed "Outside Click" logic for the 3-dot menu using mousedown.
4. Added dynamic key (network-index) to force-refresh account cards on network change.
5. Added a network badge (MAINNET/TESTNET) to the wallet card for better orientation.

