### PR TITLE
feat: new version modal, refactor livenet to be mainnet and remove st…

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -183,6 +183,14 @@ browser.runtime.onInstalled.addListener(params => {
   if (params.reason === 'install') {
     openInNewTab();
   }
+
+  if (params.reason === 'update') {
+    storage.set('EXTENSION_UPDATE_AVAILABLE_VERSION', '');
+  }
+});
+
+browser.runtime.onUpdateAvailable.addListener(details => {
+  storage.set('EXTENSION_UPDATE_AVAILABLE_VERSION', details.version);
 });
 
 // Ledger message handler

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -55,6 +55,7 @@ import {AccountActions} from './redux/reducer/account/slice';
 import {GlobalSelector} from './redux/reducer/global/selector';
 import {GlobalActions} from './redux/reducer/global/slice';
 import {generateUniqueColors, useAppDispatch} from './utils';
+import {UX} from './component';
 import SendInscription from '@/src/ui/pages/send-receive/send-inscription';
 import SendInscriptionConfirm from '@/src/ui/pages/send-receive/send-inscription-confirm';
 import DmtList from './pages/home-flow/components/dmt-list';
@@ -67,11 +68,22 @@ import HandleTappingAuthority from './pages/authority/handle/tapping';
 import CancelAuthorityDetail from '@/src/ui/pages/authority/cancel-authority-detail';
 import {AuthorityWarning} from '@/src/ui/pages/authority/authority-warning';
 import LedgerSignModalHost from './component/ledger-sign-modal/host';
+import {
+  getCurrentExtensionVersion,
+  getStoredExtensionUpdateVersion,
+  requestExtensionUpdateCheck,
+} from './utils/extension-update';
 
 function App() {
   const walletProvider = useWalletProvider();
   const isUnlocked = useSelector(GlobalSelector.isUnlocked);
+  const hasExtensionUpdate = useSelector(GlobalSelector.hasExtensionUpdate);
+  const extensionUpdateVersion = useSelector(
+    GlobalSelector.extensionUpdateVersion,
+  );
   const dispatch = useAppDispatch();
+  const didCheckExtensionUpdate = useRef(false);
+  const currentExtensionVersion = getCurrentExtensionVersion();
 
   const selfRef = useRef({
     settingsLoaded: false,
@@ -134,6 +146,43 @@ function App() {
       }
     });
   }, []);
+
+  useEffect(() => {
+    if (didCheckExtensionUpdate.current) {
+      return;
+    }
+
+    didCheckExtensionUpdate.current = true;
+
+    const runUpdateCheck = async () => {
+      try {
+        const pendingVersion = await getStoredExtensionUpdateVersion();
+
+        if (pendingVersion) {
+          dispatch(
+            GlobalActions.update({
+              hasExtensionUpdate: true,
+              extensionUpdateVersion: pendingVersion,
+            }),
+          );
+        }
+
+        const {status, version} = await requestExtensionUpdateCheck();
+        if (status === 'update_available' && version) {
+          dispatch(
+            GlobalActions.update({
+              hasExtensionUpdate: true,
+              extensionUpdateVersion: version,
+            }),
+          );
+        }
+      } catch (error) {
+        console.log('extension update check error', error);
+      }
+    };
+
+    runUpdateCheck();
+  }, [dispatch]);
 
   return (
     <HashRouter>
@@ -280,6 +329,18 @@ function App() {
         <Route path="/authority-warning" element={<AuthorityWarning />} />
       </Routes>
       <LedgerSignModalHost />
+      <UX.ExtensionUpdateModal
+        isOpen={hasExtensionUpdate}
+        currentVersion={currentExtensionVersion}
+        availableVersion={extensionUpdateVersion || undefined}
+        onClose={() =>
+          dispatch(
+            GlobalActions.update({
+              hasExtensionUpdate: false,
+            }),
+          )
+        }
+      />
       </>
     </HashRouter>
   );

--- a/src/ui/component/extension-update-modal/index.tsx
+++ b/src/ui/component/extension-update-modal/index.tsx
@@ -1,0 +1,62 @@
+import browser from 'webextension-polyfill';
+import ModalCustom from '../modal-custom';
+import Box from '../box-custom';
+import Button from '../button-custom';
+import Text from '../text-custom';
+
+interface ExtensionUpdateModalProps {
+  isOpen: boolean;
+  currentVersion: string;
+  availableVersion?: string;
+  onClose: () => void;
+}
+
+const ExtensionUpdateModal = ({
+  isOpen,
+  currentVersion,
+  availableVersion,
+  onClose,
+}: ExtensionUpdateModalProps) => {
+  return (
+    <ModalCustom
+      isOpen={isOpen}
+      onClose={onClose}
+      containerStyle={{
+        width: 'calc(100vw - 32px)',
+        maxWidth: '380px',
+      }}>
+      <Box layout="column" spacing="xl" style={{padding: '4px'}}>
+        <Box layout="column" spacing="xs">
+          <Text
+            title="New version available"
+            styleType="heading_18"
+            customStyles={{color: 'white'}}
+          />
+          <Text
+            title={`The current version is ${currentVersion}.${
+              availableVersion ? ` The new version is ${availableVersion}.` : ''
+            }`}
+            styleType="body_12_normal"
+          />
+          <Text
+            title="Update now to keep using the wallet with the latest fixes."
+            styleType="body_12_normal"
+          />
+        </Box>
+
+        <Box layout="row" spacing="sm" style={{marginTop: '8px'}}>
+          <Button styleType="dark" title="Later" onClick={onClose} />
+          <Button
+            styleType="primary"
+            title="Update now"
+            onClick={async () => {
+              await browser.runtime.reload();
+            }}
+          />
+        </Box>
+      </Box>
+    </ModalCustom>
+  );
+};
+
+export default ExtensionUpdateModal;

--- a/src/ui/component/index.ts
+++ b/src/ui/component/index.ts
@@ -26,6 +26,7 @@ import PinInput from './pin-input';
 import RefreshButton from './refresh-button';
 import AuthInput from './auth-input';
 import PasswordUpdateModal from './password-update-modal';
+import ExtensionUpdateModal from './extension-update-modal';
 import {Section} from './section-custom';
 import SwitchCustom from './switch-button';
 import Tabs from './tab-bar';
@@ -69,5 +70,6 @@ export const UX = {
   Dropdown,
   Badge,
   AuthInput,
-  PasswordUpdateModal
+  PasswordUpdateModal,
+  ExtensionUpdateModal,
 };

--- a/src/ui/pages/approval/components/sign-trac-tx-approval.tsx
+++ b/src/ui/pages/approval/components/sign-trac-tx-approval.tsx
@@ -3,6 +3,7 @@ import { TracApiService } from '@/src/background/service/trac-api.service';
 import { useApproval, useFee } from '../hook';
 import LayoutApprove from '../layouts';
 import WebsiteBar from '@/src/ui/component/website-bar';
+import { Network } from '@/src/wallet-instance'
 
 interface Props {
   params: {
@@ -155,7 +156,7 @@ export default function SignTracTxApproval({ params: { session, data, _builtTxDa
                 <UX.Box layout="row_between" style={{ width: '100%' }}>
                   <UX.Text title="Network" styleType="body_12_bold" customStyles={{ color: '#888' }} />
                   <UX.Text
-                    title={txData.networkId === 918 ? 'Mainnet' : 'Testnet'}
+                    title={txData.networkId === 918 ? Network.MAINNET : Network.TESTNET}
                     styleType="body_12_normal"
                     customStyles={{ color: 'white' }}
                   />

--- a/src/ui/pages/dapp/index.tsx
+++ b/src/ui/pages/dapp/index.tsx
@@ -98,7 +98,7 @@ const DappPage = () => {
             ) : (
               <UX.Box>
                 <UX.Text
-                  title={'Please change network to LIVENET'}
+                  title={'Please change network to MAINNET'}
                   styleType="body_16_bold"
                   customStyles={{color: 'white', marginBottom: '20px'}}
                 />

--- a/src/ui/pages/home-flow/components/wallet-card-item.tsx
+++ b/src/ui/pages/home-flow/components/wallet-card-item.tsx
@@ -184,7 +184,9 @@ const WalletCard = (props: IWalletCardProps) => {
               styleType="body_16_bold"
               customStyles={{color: 'white'}}
             title={`Wallet only available on ${
-              expectedNetwork === Network.TESTNET ? 'testnet' : 'mainnet'
+              expectedNetwork === Network.TESTNET 
+                ? Network.TESTNET.toLowerCase() 
+                : Network.MAINNET.toLowerCase()
             }`}
             />
           </UX.Box>
@@ -201,7 +203,7 @@ const WalletCard = (props: IWalletCardProps) => {
             <UX.Box layout="row" style={{alignItems: 'center', gap: '8px'}}>
               <UX.Text 
                 styleType="body_12_bold"
-                title={networkType === NETWORK_TYPES.MAINNET.label ? 'MAINNET' : 'TESTNET'} 
+                title={networkType === NETWORK_TYPES.MAINNET.label ? Network.MAINNET : Network.TESTNET} 
                 customStyles={{ 
                   color: networkType === NETWORK_TYPES.MAINNET.label ? 'white' : '#d3d3d3',
                   fontSize: '10px',

--- a/src/ui/pages/send-receive/send-trac.tsx
+++ b/src/ui/pages/send-receive/send-trac.tsx
@@ -90,7 +90,7 @@ const SendTrac = () => {
       const separatorIndex = address.trim().lastIndexOf('1');
       const addrPrefix = separatorIndex > 0 ? address.trim().slice(0, separatorIndex) : '';
       if (addrPrefix !== expectedHrp) {
-        setAddressError(`This is a ${addrPrefix === 'trac' ? 'mainnet' : 'testnet'} address. You are on ${networkType === Network.MAINNET ? 'mainnet' : 'testnet'}.`);
+        setAddressError(`This is a ${addrPrefix === 'trac' ? Network.MAINNET.toLowerCase() : Network.TESTNET.toLowerCase()} address. You are on ${networkType === Network.MAINNET ? Network.MAINNET.toLowerCase() : Network.TESTNET.toLowerCase()}.`);
       } else {
         setAddressError('');
       }

--- a/src/ui/pages/settings/index.tsx
+++ b/src/ui/pages/settings/index.tsx
@@ -3,22 +3,45 @@ import {UX} from '../../component';
 import {SVG} from '../../svg';
 import Navbar from '../home-flow/components/navbar-navigate';
 import LayoutScreenSettings from '../../layouts/settings';
-import {useAppSelector} from '../../utils';
+import {
+  getCurrentExtensionVersion,
+  getStoredExtensionUpdateVersion,
+  requestExtensionUpdateCheck,
+  useAppDispatch,
+  useAppSelector,
+} from '../../utils';
 import {GlobalSelector} from '../../redux/reducer/global/selector';
+import {GlobalActions} from '../../redux/reducer/global/slice';
 import {WalletSelector} from '../../redux/reducer/wallet/selector';
-import {useEffect, useMemo, useState} from 'react';
-import {ADDRESS_TYPES, NETWORK_TYPES, WALLET_TYPE} from '@/src/wallet-instance';
+import {useCallback, useEffect, useMemo, useState} from 'react';
+import {ADDRESS_TYPES, Network, NETWORK_TYPES, WALLET_TYPE} from '@/src/wallet-instance';
 import {AccountSelector} from '../../redux/reducer/account/selector';
 import {useWalletProvider} from '../../gateway/wallet-provider';
 import {useIsTabOpen, useOpenInTab} from '../../browser';
 import {useResetReduxState} from '../../hook/reset-redux-state';
 import {ConnectedSite} from '@/src/background/service/permission.service';
 import {useIsTracSingleWallet} from '../home-flow/hook';
+import {useCustomToast} from '../../component/toast-custom';
 
 const SettingPage = () => {
+  type SettingsItem = {
+    title: string;
+    desc?: string;
+    link?: string;
+    type?: string;
+    onClick?: () => void | Promise<void>;
+    loading?: boolean;
+  };
+
   //! State
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+  const {showToast} = useCustomToast();
   const networkType = useAppSelector(GlobalSelector.networkType);
+  const hasExtensionUpdate = useAppSelector(GlobalSelector.hasExtensionUpdate);
+  const extensionUpdateVersion = useAppSelector(
+    GlobalSelector.extensionUpdateVersion,
+  );
   const activeWallet = useAppSelector(WalletSelector.activeWallet);
   const activeAccount = useAppSelector(AccountSelector.activeAccount);
   const currentAuthority = useAppSelector(AccountSelector.currentAuthority);
@@ -26,6 +49,8 @@ const SettingPage = () => {
   const openInTab = useOpenInTab();
   const [isExtensionInTab, setIsExtensionInTab] = useState(false);
   const [sitesConnected, setSitesConnected] = useState<ConnectedSite[]>([]);
+  const [isCheckingUpdate, setIsCheckingUpdate] = useState(false);
+  const currentExtensionVersion = getCurrentExtensionVersion();
 
   const getSites = async () => {
     const sites = await wallet.getConnectedSites();
@@ -39,16 +64,64 @@ const SettingPage = () => {
   const resetReduxState = useResetReduxState();
   const isTracSingleWallet = useIsTracSingleWallet();
 
-  useMemo(async () => {
-    setIsExtensionInTab(await isTabOpen());
+  useEffect(() => {
+    const syncExtensionTabState = async () => {
+      setIsExtensionInTab(await isTabOpen());
+    };
+
+    syncExtensionTabState();
   }, [isTabOpen]);
 
   useEffect(() => {
     getSites();
   }, []);
 
+  const handleCheckForUpdates = useCallback(async () => {
+    if (isCheckingUpdate) {
+      return;
+    }
+
+    setIsCheckingUpdate(true);
+
+    try {
+      const storedVersion = await getStoredExtensionUpdateVersion();
+      if (storedVersion) {
+        dispatch(
+          GlobalActions.update({
+            hasExtensionUpdate: true,
+            extensionUpdateVersion: storedVersion,
+          }),
+        );
+        return;
+      }
+
+      const {status, version} = await requestExtensionUpdateCheck();
+      if (status === 'update_available' && version) {
+        dispatch(
+          GlobalActions.update({
+            hasExtensionUpdate: true,
+            extensionUpdateVersion: version,
+          }),
+        );
+        return;
+      }
+
+      showToast({
+        type: 'success',
+        title: 'You are on the latest version.',
+      });
+    } catch (error) {
+      showToast({
+        type: 'error',
+        title: 'Unable to check for updates.',
+      });
+    } finally {
+      setIsCheckingUpdate(false);
+    }
+  }, [dispatch, isCheckingUpdate, showToast]);
+
   //! Function
-  const settingsFunction = useMemo(() => {
+  const settingsFunction = useMemo<SettingsItem[]>(() => {
     let descAddress: string;
     const item = ADDRESS_TYPES[activeWallet.addressType];
     const hdPath = activeWallet.derivationPath || item?.derivationPath;
@@ -70,6 +143,16 @@ const SettingPage = () => {
 
     const functions = [
       {
+        title: 'App Version',
+        desc: isCheckingUpdate
+          ? 'Checking for updates...'
+          : hasExtensionUpdate
+            ? `Update available: ${extensionUpdateVersion}`
+            : `Installed version: ${currentExtensionVersion}`,
+        onClick: handleCheckForUpdates,
+        loading: isCheckingUpdate,
+      },
+      {
         title: 'Bitcoin Address Type',
         desc: descAddress,
         link: '/setting/choose-address',
@@ -87,7 +170,7 @@ const SettingPage = () => {
       {
         title: 'Network',
         desc:
-          networkType === NETWORK_TYPES.MAINNET.label ? 'LIVENET' : networkType,
+          networkType === NETWORK_TYPES.MAINNET.label ? Network.MAINNET : networkType,
         link: '/setting/network-type',
       },
       {
@@ -126,6 +209,11 @@ const SettingPage = () => {
     sitesConnected,
     currentAuthority,
     isTracSingleWallet,
+    hasExtensionUpdate,
+    extensionUpdateVersion,
+    currentExtensionVersion,
+    isCheckingUpdate,
+    handleCheckForUpdates,
   ]);
 
   const handleExpandView = async () => {
@@ -150,11 +238,27 @@ const SettingPage = () => {
                 <UX.Box
                   key={item.title}
                   layout="box_border"
-                  style={{cursor: 'pointer'}}
+                  style={{
+                    cursor: item.onClick || item.link ? 'pointer' : 'default',
+                    opacity: item.loading ? 0.7 : 1,
+                  }}
                   onClick={() => {
+                    if (item.loading) {
+                      return;
+                    }
+                    if (item.onClick) {
+                      item.onClick();
+                      return;
+                    }
                     if (item.type) {
-                      navigate(`${item.link}?type=${item.type}`);
-                    } else navigate(item.link);
+                      if (item.link) {
+                        navigate(`${item.link}?type=${item.type}`);
+                      }
+                      return;
+                    }
+                    if (item.link) {
+                      navigate(item.link);
+                    }
                   }}>
                   <UX.Box>
                     <UX.Text

--- a/src/ui/pages/settings/network-type.tsx
+++ b/src/ui/pages/settings/network-type.tsx
@@ -71,7 +71,7 @@ const NetWorkType = () => {
             onClick={() => !isTracSingleWallet && handleChangeNetwork(Network.TESTNET)}
             style={isTracSingleWallet && networkType !== Network.TESTNET ? {opacity: 0.4, cursor: 'not-allowed'} : {}}>
             <UX.Text
-              title="TESTNET"
+              title={Network.TESTNET}
               styleType="body_16_bold"
               customStyles={{color: 'white'}}
             />
@@ -82,7 +82,7 @@ const NetWorkType = () => {
             onClick={() => !isTracSingleWallet && handleChangeNetwork(Network.MAINNET)}
             style={isTracSingleWallet && networkType !== Network.MAINNET ? {opacity: 0.4, cursor: 'not-allowed'} : {}}>
             <UX.Text
-              title="LIVENET"
+              title={Network.MAINNET}
               styleType="body_16_bold"
               customStyles={{color: 'white'}}
             />

--- a/src/ui/redux/reducer/global/selector.ts
+++ b/src/ui/redux/reducer/global/selector.ts
@@ -12,5 +12,7 @@ export const GlobalSelector = {
   auth: (state: AppState) => state.globalReducer.auth,
   showPasswordUpdateModal: (state: AppState) => state.globalReducer.showPasswordUpdateModal,
   currentPassword: (state: AppState) => state.globalReducer.currentPassword,
-  isLegacyUser: (state: AppState) => state.globalReducer.isLegacyUser
+  isLegacyUser: (state: AppState) => state.globalReducer.isLegacyUser,
+  hasExtensionUpdate: (state: AppState) => state.globalReducer.hasExtensionUpdate,
+  extensionUpdateVersion: (state: AppState) => state.globalReducer.extensionUpdateVersion,
 };

--- a/src/ui/redux/reducer/global/slice.ts
+++ b/src/ui/redux/reducer/global/slice.ts
@@ -14,6 +14,8 @@ export interface GlobalState {
   currentPassword: string;
   passwordUpgraded: boolean;
   isLegacyUser: boolean;
+  hasExtensionUpdate: boolean;
+  extensionUpdateVersion: string;
 }
 
 export const initialState: GlobalState = {
@@ -29,7 +31,9 @@ export const initialState: GlobalState = {
   showPasswordUpdateModal: false,
   currentPassword: '',
   passwordUpgraded: false,
-  isLegacyUser: false
+  isLegacyUser: false,
+  hasExtensionUpdate: false,
+  extensionUpdateVersion: '',
 };
 
 const GlobalSlice = createSlice({
@@ -39,12 +43,14 @@ const GlobalSlice = createSlice({
     update(
       state,
       action: {
-        payload: {
+      payload: {
           isUnlocked?: boolean;
           isReady?: boolean;
           isBooted?: boolean;
           showPasswordUpdateModal?: boolean;
           currentPassword?: string;
+          hasExtensionUpdate?: boolean;
+          extensionUpdateVersion?: string;
         };
       },
     ) {

--- a/src/ui/utils/extension-update.ts
+++ b/src/ui/utils/extension-update.ts
@@ -1,0 +1,34 @@
+import browser from 'webextension-polyfill';
+
+export const EXTENSION_UPDATE_STORAGE_KEY =
+  'EXTENSION_UPDATE_AVAILABLE_VERSION';
+
+export const getCurrentExtensionVersion = () => {
+  return (
+    browser.runtime.getManifest().version_name ??
+    browser.runtime.getManifest().version
+  );
+};
+
+export const getStoredExtensionUpdateVersion = async () => {
+  const storedUpdate = await browser.storage.local.get(
+    EXTENSION_UPDATE_STORAGE_KEY,
+  );
+
+  return storedUpdate?.[EXTENSION_UPDATE_STORAGE_KEY] ?? '';
+};
+
+export const requestExtensionUpdateCheck = async () => {
+  const [status, details] = await browser.runtime.requestUpdateCheck();
+
+  if (status === 'update_available' && details?.version) {
+    await browser.storage.local.set({
+      [EXTENSION_UPDATE_STORAGE_KEY]: details.version,
+    });
+  }
+
+  return {
+    status,
+    version: details?.version ?? '',
+  };
+};

--- a/src/ui/utils/index.ts
+++ b/src/ui/utils/index.ts
@@ -302,3 +302,5 @@ export const hasWalletsWithAccounts = async (wallet: any): Promise<boolean> => {
     return false;
   }
 };
+
+export * from './extension-update';

--- a/src/wallet-instance/constant.ts
+++ b/src/wallet-instance/constant.ts
@@ -67,15 +67,15 @@ export const ADDRESS_TYPES: {
 export const NETWORK_TYPES = {
   MAINNET: {
     value: Network.MAINNET,
-    label: 'MAINNET',
-    name: 'livenet',
-    validNames: [0, 'livenet', 'mainnet'],
+    label: Network.MAINNET,
+    name: Network.MAINNET.toLowerCase(),
+    validNames: [0, Network.MAINNET.toLowerCase()],
   },
   TESTNET: {
     value: Network.TESTNET,
-    label: 'TESTNET',
-    name: 'testnet',
-    validNames: ['testnet'],
+    label: Network.TESTNET,
+    name: Network.TESTNET.toLowerCase(),
+    validNames: [Network.TESTNET.toLowerCase()],
   },
 };
 

--- a/tests/background/provider.test.ts
+++ b/tests/background/provider.test.ts
@@ -24,7 +24,7 @@ jest.mock('webextension-polyfill', () => {
 
 // MOCK 3: Singleton Services
 jest.mock('../../src/background/service/singleton', () => ({
-  networkConfig: { getActiveNetwork: jest.fn().mockReturnValue('MAINNET') },
+  networkConfig: { getActiveNetwork: jest.fn().mockReturnValue(Network.MAINNET) },
   walletConfig: {},
   accountConfig: {},
   walletService: {},
@@ -45,6 +45,7 @@ jest.mock('@noble/secp256k1', () => ({
 
 import * as bitcoin from 'bitcoinjs-lib';
 import Provider from '../../src/background/provider'; 
+import { Network } from '@/src/wallet-instance'
 
 describe('Provider PSBT Extraction Integration', () => {
   it('should successfully extract a full transaction from a PSBT containing an OP_RETURN output', async () => {


### PR DESCRIPTION
### Description
This PR introduces a new UI mechanism to notify users about pending extension updates and refactors the network nomenclatures across the application for better consistency.

### Key Changes
* **Version Update Modal:** Implemented a background listener and a modal to alert users when a new extension update is available, allowing them to reload and apply the new version seamlessly.
* **Network Nomenclature:** Changed the display name from `LIVENET` to `MAINNET` across the app.
* **Code Refactoring:** Removed all hardcoded, loose string literals for networks (e.g., `"mainnet"`, `"testnet"`) and replaced them with the strongly-typed `Network.MAINNET` and `Network.TESTNET` constants to prevent typos and improve maintainability.